### PR TITLE
bug: create_qr_code: Do not add BOM to string for QRcode

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -173,7 +173,7 @@ def create_qr_code(text, size, correction, fill_color):
         box_size=size,
         border=0,
     )
-    qr.add_data(text.encode("utf-8-sig"))
+    qr.add_data(text.encode("utf-8"))
     qr.make(fit=True)
     qr_img = qr.make_image(
         fill_color='red' if (255, 0, 0) == fill_color else 'black',


### PR DESCRIPTION
Adding a BOM breaks detection of anything that is not a string, http(s)://, mailto etc. Since there is no safe way to know if the input text is just "text", or something to be parsed that may break with BOM, remove the BOM in it's entirity, do not try to work around it with string startswith matching.